### PR TITLE
[feature] Shorten the fish prompt path

### DIFF
--- a/fish/functions/fish_prompt.fish
+++ b/fish/functions/fish_prompt.fish
@@ -26,7 +26,7 @@ function fish_prompt
     set_color normal
   
     set_color '009900'
-    printf ' [%s]' (pwd)
+    printf ' [%s]' (prompt_pwd)
     set_color normal
 
     printf '%s ' (__fish_git_prompt)


### PR DESCRIPTION
Decided to use the short path in the shell prompt. The longer prompt proved to be a bit much for long-long paths.
